### PR TITLE
getBaseUri

### DIFF
--- a/Library/Phalcon/Http/Client/Request.php
+++ b/Library/Phalcon/Http/Client/Request.php
@@ -55,7 +55,7 @@ abstract class Request
 
     public function getBaseUri()
     {
-        return $this->baseUri->toString();
+        return $this->baseUri;
     }
 
     public function resolveUri($uri)


### PR DESCRIPTION
Error: Fatal error: Call to undefined method Phalcon\Http\Uri::toString()

I see that the Uri class has the magic function, so we don't need add `->toString()`
